### PR TITLE
[increment patch] Added reorder first and last and only item logic

### DIFF
--- a/demo/demo-list-usage.js
+++ b/demo/demo-list-usage.js
@@ -1,5 +1,6 @@
 import '../list-item-accumulator.js';
 import '@brightspace-ui/core/components/list/list.js';
+import '@brightspace-ui/core/components/menu/menu-item.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { ifDefined } from 'lit-html/directives/if-defined';
 import { nothing } from 'lit-html';
@@ -80,6 +81,7 @@ class DemoAccumulatorUsage extends LitElement {
 						<div>${item.name}</div>
 						<div slot="secondary">${item.secondary}</div>
 						${item.supporting ? html`<div slot="supporting-info">${item.supporting}</div>` : nothing }
+						<d2l-menu-item slot="secondary-action" text="Remove"></d2l-menu-item>
 					</d2l-labs-list-item-accumulator>
 				`)}
 			</d2l-list>

--- a/list-item-accumulator.js
+++ b/list-item-accumulator.js
@@ -335,12 +335,13 @@ class ListItemAccumulator extends ListItemDragDropMixin(RtlMixin(LocalizeMixin(L
 
 	_renderReorderActions() {
 		if (!this.draggable) return nothing;
+		const parent = this.parentNode;
 		// if direction is up and this is the first item, don't render up
-		const upAction = this.previousElementSibling ? html`
+		const upAction = parent.querySelector('d2l-labs-list-item-accumulator:first-of-type') !== this ? html`
 			<d2l-menu-item text="${this.localize('moveUp')}" @click="${this._onClickMoveUp}" @keydown="${this._onKeyDownMoveUp}"></d2l-menu-item>
 			` : nothing;
 		// if direction is down and this is the last item, don't render down
-		const downAction = this.nextElementSibling ? html`
+		const downAction = parent.querySelector('d2l-labs-list-item-accumulator:last-of-type') !== this ? html`
 			<d2l-menu-item text="${this.localize('moveDown')}" @click="${this._onClickMoveDown}" @keydown="${this._onKeyDownMoveDown}"></d2l-menu-item>
 			` : nothing;
 		return html`

--- a/list-item-accumulator.js
+++ b/list-item-accumulator.js
@@ -233,6 +233,11 @@ class ListItemAccumulator extends ListItemDragDropMixin(RtlMixin(LocalizeMixin(L
 		super.firstUpdated(changedProperties);
 	}
 
+	get isOnlyChild() {
+		const nodes = this.parentNode.querySelectorAll('d2l-labs-list-item-accumulator');
+		return nodes.length ? nodes[0] === this : false;
+	}
+
 	render() {
 		const mobilePrimaryAction = this._primaryAction ? html`
 			<d2l-menu-item
@@ -247,7 +252,7 @@ class ListItemAccumulator extends ListItemDragDropMixin(RtlMixin(LocalizeMixin(L
 		const dropdownClasses = {
 			'd2l-hidden':
 				(!this._hasSecondaryActions && !this.draggable) ||
-				(!this.nextElementSibling && !this.previousElementSibling && !this._hasSecondaryActions) // only child
+				(this.isOnlyChild && !this._hasSecondaryActions)
 		};
 		return html`
 			${this._renderTopPlacementMarker(html`<d2l-list-item-placement-marker></d2l-list-item-placement-marker>`)}

--- a/list-item-accumulator.js
+++ b/list-item-accumulator.js
@@ -236,12 +236,7 @@ class ListItemAccumulator extends ListItemDragDropMixin(RtlMixin(LocalizeMixin(L
 		super.firstUpdated(changedProperties);
 	}
 
-	// todo: translations
 	render() {
-		const reorderActions = this.draggable ? html`
-			<d2l-menu-item text="${this.localize('moveUp')}" @click="${this._onClickMoveUp}" @keydown="${this._onKeyDownMoveUp}"></d2l-menu-item>
-			<d2l-menu-item text="${this.localize('moveDown')}" @click="${this._onClickMoveDown}" @keydown="${this._onKeyDownMoveDown}"></d2l-menu-item>
-		` : nothing;
 		const mobilePrimaryAction = this._primaryAction ? html`
 			<d2l-menu-item
 				class="d2l-primary-action-mobile"
@@ -253,7 +248,9 @@ class ListItemAccumulator extends ListItemDragDropMixin(RtlMixin(LocalizeMixin(L
 			'd2l-hovering': this._hovering
 		};
 		const dropdownClasses = {
-			'd2l-hidden': !this._hasSecondaryActions && !this.draggable
+			'd2l-hidden':
+				(!this._hasSecondaryActions && !this.draggable) ||
+				(!this.nextElementSibling && !this.previousElementSibling && !this._hasSecondaryActions) // only child
 		};
 		return html`
 			${this._renderTopPlacementMarker(html`<d2l-list-item-placement-marker></d2l-list-item-placement-marker>`)}
@@ -281,7 +278,7 @@ class ListItemAccumulator extends ListItemDragDropMixin(RtlMixin(LocalizeMixin(L
 										<d2l-menu label="${this.localize('secondaryActions')}">
 											${mobilePrimaryAction}
 											<slot name="secondary-action"></slot>
-											${reorderActions}
+											${this._renderReorderActions()}
 										</d2l-menu>
 									</d2l-dropdown-menu>
 								</d2l-dropdown-more>
@@ -337,6 +334,22 @@ class ListItemAccumulator extends ListItemDragDropMixin(RtlMixin(LocalizeMixin(L
 
 	_renderOutsideControl(dragHandle) {
 		return html`<div slot="outside-control">${dragHandle}</div>`;
+	}
+
+	_renderReorderActions() {
+		if (!this.draggable) return nothing;
+		// if direction is up and this is the first item, don't render up
+		const upAction = this.previousElementSibling ? html`
+			<d2l-menu-item text="${this.localize('moveUp')}" @click="${this._onClickMoveUp}" @keydown="${this._onKeyDownMoveUp}"></d2l-menu-item>
+			` : nothing;
+		// if direction is down and this is the last item, don't render down
+		const downAction = this.nextElementSibling ? html`
+			<d2l-menu-item text="${this.localize('moveDown')}" @click="${this._onClickMoveDown}" @keydown="${this._onKeyDownMoveDown}"></d2l-menu-item>
+			` : nothing;
+		return html`
+			${upAction}
+			${downAction}
+		`;
 	}
 
 	_renderOutsideControlAction(dragTarget) {

--- a/list-item-accumulator.js
+++ b/list-item-accumulator.js
@@ -235,7 +235,7 @@ class ListItemAccumulator extends ListItemDragDropMixin(RtlMixin(LocalizeMixin(L
 
 	get isOnlyChild() {
 		const nodes = this.parentNode.querySelectorAll('d2l-labs-list-item-accumulator');
-		return nodes.length ? nodes[0] === this : false;
+		return nodes.length === 1 ? nodes[0] === this : false;
 	}
 
 	render() {

--- a/list-item-accumulator.js
+++ b/list-item-accumulator.js
@@ -195,9 +195,6 @@ class ListItemAccumulator extends ListItemDragDropMixin(RtlMixin(LocalizeMixin(L
 				.d2l-primary-action-mobile {
 					display: none;
 				}
-				::slotted(d2l-menu-item[slot="secondary-action"]:not(:hover):first-of-type) {
-					border-top-color: transparent;
-				}
 				::slotted([slot="primary-action"]) {
 					display: inline-block;
 				}
@@ -277,8 +274,8 @@ class ListItemAccumulator extends ListItemDragDropMixin(RtlMixin(LocalizeMixin(L
 									<d2l-dropdown-menu id="${this._dropdownId}">
 										<d2l-menu label="${this.localize('secondaryActions')}">
 											${mobilePrimaryAction}
-											<slot name="secondary-action"></slot>
 											${this._renderReorderActions()}
+											<slot name="secondary-action"></slot>
 										</d2l-menu>
 									</d2l-dropdown-menu>
 								</d2l-dropdown-more>

--- a/test/list-item-accumulator.test.js
+++ b/test/list-item-accumulator.test.js
@@ -28,29 +28,33 @@ describe('d2l-labs-list-item-accumulator', () => {
 		it('should only show "Move Down" when first item', async() => {
 			const el = await fixture(basicList);
 			const items = el.firstElementChild.shadowRoot.querySelectorAll('d2l-menu-item');
-			expect(items).to.not.be.null;
-			expect(items).to.have.lengthOf(1);
-			expect(items[0].text).to.equal('Move Down');
+			const itemsWithText = Array.from(items).filter(item => item.text);
+			expect(itemsWithText.find(item => item.text === 'Move Down')).to.exist;
+			expect(itemsWithText.find(item => item.text === 'Move Up')).to.be.undefined;
 		});
 
 		it('should only show "Move Up" when last item', async() => {
 			const el = await fixture(basicList);
 			const items = el.lastElementChild.shadowRoot.querySelectorAll('d2l-menu-item');
-			expect(items).to.not.be.null;
-			expect(items).to.have.lengthOf(1);
-			expect(items[0].text).to.equal('Move Up');
+			const itemsWithText = Array.from(items).filter(item => item.text);
+			expect(itemsWithText.find(item => item.text === 'Move Down')).to.be.undefined;
+			expect(itemsWithText.find(item => item.text === 'Move Up')).to.exist;
 		});
 
 		it('should show both actions when middle item', async() => {
 			const el = await fixture(basicList);
 			const items = el.querySelector(':nth-child(2)').shadowRoot.querySelectorAll('d2l-menu-item');
-			expect(items).to.not.be.null;
-			expect(items).to.have.lengthOf(2);
+			const itemsWithText = Array.from(items).filter(item => item.text);
+			expect(itemsWithText.find(item => item.text === 'Move Down')).to.exist;
+			expect(itemsWithText.find(item => item.text === 'Move Up')).to.exist;
 		});
 
 		it('should show no actions when only item in list', async() => {
 			const el = await fixture(html`<div><d2l-labs-list-item-accumulator draggable="true" key="1"></d2l-labs-list-item-accumulator></div>`);
-			expect(el.firstElementChild.shadowRoot.querySelector('d2l-menu-item')).to.be.null;
+			const items = el.firstElementChild.shadowRoot.querySelectorAll('d2l-menu-item');
+			const itemsWithText = Array.from(items).filter(item => item.text);
+			expect(itemsWithText.find(item => item.text === 'Move Down')).to.be.undefined;
+			expect(itemsWithText.find(item => item.text === 'Move Up')).to.be.undefined;
 		});
 	});
 

--- a/test/list-item-accumulator.test.js
+++ b/test/list-item-accumulator.test.js
@@ -20,9 +20,9 @@ describe('d2l-labs-list-item-accumulator', () => {
 	describe('reorder actions', () => {
 		const basicList = html`
 		<div>
-			<d2l-labs-list-item-accumulator draggable key="1"></d2l-labs-list-item-accumulator>
-			<d2l-labs-list-item-accumulator draggable key="2"></d2l-labs-list-item-accumulator>
-			<d2l-labs-list-item-accumulator draggable key="3"></d2l-labs-list-item-accumulator>
+			<d2l-labs-list-item-accumulator draggable="true" key="1"></d2l-labs-list-item-accumulator>
+			<d2l-labs-list-item-accumulator draggable="true" key="2"></d2l-labs-list-item-accumulator>
+			<d2l-labs-list-item-accumulator draggable="true" key="3"></d2l-labs-list-item-accumulator>
 		</div>`;
 
 		it('should only show "Move Down" when first item', async() => {
@@ -49,7 +49,7 @@ describe('d2l-labs-list-item-accumulator', () => {
 		});
 
 		it('should show no actions when only item in list', async() => {
-			const el = await fixture(html`<div><d2l-labs-list-item-accumulator draggable key="1"></d2l-labs-list-item-accumulator></div>`);
+			const el = await fixture(html`<div><d2l-labs-list-item-accumulator draggable="true" key="1"></d2l-labs-list-item-accumulator></div>`);
 			expect(el.firstElementChild.shadowRoot.querySelector('d2l-menu-item')).to.be.null;
 		});
 	});

--- a/test/list-item-accumulator.test.js
+++ b/test/list-item-accumulator.test.js
@@ -17,4 +17,41 @@ describe('d2l-labs-list-item-accumulator', () => {
 		});
 	});
 
+	describe('reorder actions', () => {
+		const basicList = html`
+		<div>
+			<d2l-labs-list-item-accumulator draggable key="1"></d2l-labs-list-item-accumulator>
+			<d2l-labs-list-item-accumulator draggable key="2"></d2l-labs-list-item-accumulator>
+			<d2l-labs-list-item-accumulator draggable key="3"></d2l-labs-list-item-accumulator>
+		</div>`;
+
+		it('should only show "Move Down" when first item', async() => {
+			const el = await fixture(basicList);
+			const items = el.firstElementChild.shadowRoot.querySelectorAll('d2l-menu-item');
+			expect(items).to.not.be.null;
+			expect(items).to.have.lengthOf(1);
+			expect(items[0].text).to.equal('Move Down');
+		});
+
+		it('should only show "Move Up" when last item', async() => {
+			const el = await fixture(basicList);
+			const items = el.lastElementChild.shadowRoot.querySelectorAll('d2l-menu-item');
+			expect(items).to.not.be.null;
+			expect(items).to.have.lengthOf(1);
+			expect(items[0].text).to.equal('Move Up');
+		});
+
+		it('should show both actions when middle item', async() => {
+			const el = await fixture(basicList);
+			const items = el.querySelector(':nth-child(2)').shadowRoot.querySelectorAll('d2l-menu-item');
+			expect(items).to.not.be.null;
+			expect(items).to.have.lengthOf(2);
+		});
+
+		it('should show no actions when only item in list', async() =>{
+			const el = await fixture(html`<div><d2l-labs-list-item-accumulator draggable key="1"></d2l-labs-list-item-accumulator></div>`);
+			expect(el.firstElementChild.shadowRoot.querySelector('d2l-menu-item')).to.be.null;
+		});
+	});
+
 });

--- a/test/list-item-accumulator.test.js
+++ b/test/list-item-accumulator.test.js
@@ -48,7 +48,7 @@ describe('d2l-labs-list-item-accumulator', () => {
 			expect(items).to.have.lengthOf(2);
 		});
 
-		it('should show no actions when only item in list', async() =>{
+		it('should show no actions when only item in list', async() => {
 			const el = await fixture(html`<div><d2l-labs-list-item-accumulator draggable key="1"></d2l-labs-list-item-accumulator></div>`);
 			expect(el.firstElementChild.shadowRoot.querySelector('d2l-menu-item')).to.be.null;
 		});


### PR DESCRIPTION
## Context
[DE39891](https://rally1.rallydev.com/#/detail/defect/406934850716?fdp=true)
[DE40001](https://rally1.rallydev.com/#/detail/defect/409224266100?fdp=true)

* Adds logic to show only relevant "Move Up" and "Move Down" actions
* Hides context menu if there are no secondary actions and there is only one item in the list
* Moves the `secondary-action` slot to below the reorder actions

## UX Result
### First Item
<img width="887" alt="Screen Shot 2020-08-10 at 1 48 25 PM" src="https://user-images.githubusercontent.com/2412740/89813844-4877ec80-db10-11ea-947f-d17de5b24d19.png">

### Last Item
<img width="892" alt="Screen Shot 2020-08-10 at 1 48 32 PM" src="https://user-images.githubusercontent.com/2412740/89813856-4e6dcd80-db10-11ea-880d-b4b326e16c07.png">

### Only Item
<img width="851" alt="Screen Shot 2020-08-10 at 1 49 00 PM" src="https://user-images.githubusercontent.com/2412740/89813876-562d7200-db10-11ea-9dd8-47b3e2d015e8.png">

### Menu item order
<img width="253" alt="Screen Shot 2020-08-10 at 2 09 07 PM" src="https://user-images.githubusercontent.com/2412740/89815648-1fa52680-db13-11ea-9417-5d7ac969fde5.png">


## Quality
* New unit tests added for these scenarios
* Tested with demo page