### PR TITLE
updated border colour for hovering

### DIFF
--- a/list-item-accumulator.js
+++ b/list-item-accumulator.js
@@ -67,7 +67,7 @@ class ListItemAccumulator extends ListItemDragDropMixin(RtlMixin(LocalizeMixin(L
 				transform: rotate(-1deg);
 			}
 			:host(:not([dragging])) .d2l-hovering {
-				border-color: var(--d2l-color-mica);
+				border-color: var(--d2l-color-chromite);
 			}
 			:host(:not([dragging])) .d2l-hovering .d2l-list-item-drag-shadow {
 				animation-duration: 2s;


### PR DESCRIPTION
Updated border colour when hovering to have contrast level for WCAG AAA compliance for [DE37674](https://rally1.rallydev.com/#/357252966636d/backlog?detail=%2Fdefect%2F366102021928).