### PR TITLE
fix: refocus after using keyboard mode to move item

### DIFF
--- a/list-item-accumulator-mixin.js
+++ b/list-item-accumulator-mixin.js
@@ -332,9 +332,6 @@ export const ListItemAccumulatorMixin = superclass => class extends ListItemDrag
 		}
 	}
 
-	_afterHeyDownFocus(){
-		this.shadowRoot.getElementById(this._dropdownButtonId).focus();
-	}
 	_renderOutsideControl(dragHandle) {
 		return html`<div slot="outside-control">${dragHandle}</div>`;
 	}

--- a/list-item-accumulator-mixin.js
+++ b/list-item-accumulator-mixin.js
@@ -319,15 +319,21 @@ export const ListItemAccumulatorMixin = superclass => class extends ListItemDrag
 		this._primaryAction.click();
 	}
 	async _onKeyDownMoveDown(e) {
+		this._onKeyDownAction(e, dropLocation.shiftDown);
+	}
+	_onKeyDownMoveUp(e) {
+		this._onKeyDownAction(e, dropLocation.shiftUp);
+	}
+	async _onKeyDownAction(e, action) {
 		if (e.keyCode === keyCodes.ENTER || e.keyCode === keyCodes.SPACE) {
-			await this._annoucePositionChange(this.key, null, dropLocation.shiftDown);
+			await this._annoucePositionChange(this.key, null, action);
 
 			this.shadowRoot.getElementById(this._dropdownButtonId).focus();
 		}
-		return false;
 	}
-	_onKeyDownMoveUp(e) {
-		return (e.keyCode === keyCodes.ENTER || e.keyCode === keyCodes.SPACE) && this._annoucePositionChange(this.key, null, dropLocation.shiftUp);
+
+	_afterHeyDownFocus(){
+		this.shadowRoot.getElementById(this._dropdownButtonId).focus();
 	}
 	_renderOutsideControl(dragHandle) {
 		return html`<div slot="outside-control">${dragHandle}</div>`;

--- a/list-item-accumulator-mixin.js
+++ b/list-item-accumulator-mixin.js
@@ -318,8 +318,13 @@ export const ListItemAccumulatorMixin = superclass => class extends ListItemDrag
 	_onClickPrimaryMenuItem() {
 		this._primaryAction.click();
 	}
-	_onKeyDownMoveDown(e) {
-		return (e.keyCode === keyCodes.ENTER || e.keyCode === keyCodes.SPACE) && this._annoucePositionChange(this.key, null, dropLocation.shiftDown);
+	async _onKeyDownMoveDown(e) {
+		if (e.keyCode === keyCodes.ENTER || e.keyCode === keyCodes.SPACE) {
+			await this._annoucePositionChange(this.key, null, dropLocation.shiftDown);
+
+			this.shadowRoot.getElementById(this._dropdownButtonId).focus();
+		}
+		return false;
 	}
 	_onKeyDownMoveUp(e) {
 		return (e.keyCode === keyCodes.ENTER || e.keyCode === keyCodes.SPACE) && this._annoucePositionChange(this.key, null, dropLocation.shiftUp);

--- a/list-item-accumulator-mixin.js
+++ b/list-item-accumulator-mixin.js
@@ -310,26 +310,23 @@ export const ListItemAccumulatorMixin = superclass => class extends ListItemDrag
 		}
 	}
 	_onClickMoveDown() {
-		this._annoucePositionChange(this.key, null, dropLocation.shiftDown);
+		this._onMoveAction(dropLocation.shiftDown);
 	}
 	_onClickMoveUp() {
-		this._annoucePositionChange(this.key, null, dropLocation.shiftUp);
+		this._onMoveAction(dropLocation.shiftUp);
 	}
 	_onClickPrimaryMenuItem() {
 		this._primaryAction.click();
 	}
-	async _onKeyDownMoveDown(e) {
-		this._onKeyDownAction(e, dropLocation.shiftDown);
+	_onKeyDownMoveDown(e) {
+		(e.keyCode === keyCodes.ENTER || e.keyCode === keyCodes.SPACE) && this._onMoveAction(dropLocation.shiftDown);
 	}
 	_onKeyDownMoveUp(e) {
-		this._onKeyDownAction(e, dropLocation.shiftUp);
+		(e.keyCode === keyCodes.ENTER || e.keyCode === keyCodes.SPACE) && this._onMoveAction(dropLocation.shiftUp);
 	}
-	async _onKeyDownAction(e, action) {
-		if (e.keyCode === keyCodes.ENTER || e.keyCode === keyCodes.SPACE) {
-			await this._annoucePositionChange(this.key, null, action);
-
-			this.shadowRoot.getElementById(this._dropdownButtonId).focus();
-		}
+	async _onMoveAction(action) {
+		await this._annoucePositionChange(this.key, null, action);
+		this.shadowRoot.getElementById(this._dropdownButtonId).focus();
 	}
 
 	_renderOutsideControl(dragHandle) {


### PR DESCRIPTION
### Context:
[DE42145](https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fdefect%2F486215217088)
When using keyboard mode to move an item down, focus is currently lost on the item. This refactors the code to have move up and down focus in the same way after the position is changed.

### Quality:
Tested on polarislocalbsi in Chrome.