### PR TITLE
DE54333 Add z-index ordering to menu

### DIFF
--- a/list-item-accumulator-mixin.js
+++ b/list-item-accumulator-mixin.js
@@ -156,6 +156,7 @@ export const ListItemAccumulatorMixin = superclass => class extends ListItemDrag
 			.d2l-list-item-actions-container {
 				display: flex;
 				margin-right: 0.8rem;
+				z-index: 5;
 			}
 			:host([dir="rtl"]) .d2l-list-item-actions-container {
 				margin-left: 0.8rem;


### PR DESCRIPTION
[DE54333](https://rally1.rallydev.com/#/?detail=/defect/716646337751&fdp=true): Learning Paths: The courses within Learning paths can not be reordered/removed

The `d2l-list-item-actions-container` which houses the action items is currently is visually obscured by the `content-action` div, which serves as a white background, and is unable to click due to `outside-control-action` which serves to grab the list item. 

This PR adds a z-index to `d2l-list-item-actions-container` which places it above the two other divs, allowing it to be seen and interacted with once more.

The issue is reproduceable via demo page items `List accumulator (with illustration)` and `List accumulator (draggable)` which are both suffering from the menu being hidden. Testing shows this resolves the issue in the demos as well as in the above defect for Learning Paths.