### PR TITLE
fix: lit dependencies

### DIFF
--- a/demo/demo-list-usage.js
+++ b/demo/demo-list-usage.js
@@ -1,10 +1,9 @@
 import '../list-item-accumulator.js';
 import '@brightspace-ui/core/components/list/list.js';
 import '@brightspace-ui/core/components/menu/menu-item.js';
-import { css, html, LitElement } from 'lit-element/lit-element.js';
-import { ifDefined } from 'lit-html/directives/if-defined.js';
-import { nothing } from 'lit-html';
-import { repeat } from 'lit-html/directives/repeat.js';
+import { css, html, LitElement, nothing } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { repeat } from 'lit/directives/repeat.js';
 
 class DemoAccumulatorUsage extends LitElement {
 	static get properties() {

--- a/list-item-accumulator-mixin.js
+++ b/list-item-accumulator-mixin.js
@@ -6,13 +6,12 @@ import '@brightspace-ui/core/components/list/list-item-placement-marker.js';
 import '@brightspace-ui/core/components/menu/menu.js';
 import '@brightspace-ui/core/components/menu/menu-item.js';
 import { bodyCompactStyles, bodySmallStyles, bodyStandardStyles } from '@brightspace-ui/core/components/typography/styles.js';
-import { css, html } from 'lit-element/lit-element.js';
+import { css, html, nothing } from 'lit';
 import { dropLocation, ListItemDragDropMixin } from '@brightspace-ui/core/components/list/list-item-drag-drop-mixin.js';
-import { classMap } from 'lit-html/directives/class-map.js';
+import { classMap } from 'lit/directives/class-map.js';
 import { getComposedParent } from '@brightspace-ui/core/helpers/dom.js';
 import { getUniqueId } from '@brightspace-ui/core/helpers/uniqueId.js';
 import { LocalizeDynamicMixin } from '@brightspace-ui/core/mixins/localize-dynamic-mixin.js';
-import { nothing } from 'lit-html';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 const keyCodes = Object.freeze({
 	ENTER: 13,

--- a/list-item-accumulator.js
+++ b/list-item-accumulator.js
@@ -1,5 +1,5 @@
 import { ListItemAccumulatorMixin } from './list-item-accumulator-mixin.js';
-import { LitElement } from 'lit-element/lit-element.js';
+import { LitElement } from 'lit';
 
 class ListItemAccumulator extends ListItemAccumulatorMixin(LitElement) {
 	render() {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   },
   "dependencies": {
     "@brightspace-ui/core": "^2",
-    "lit-element": "^3",
-    "lit-html": "^2"
+    "lit": "^2"
   }
 }


### PR DESCRIPTION
This isn't a prerequisite for upgrading to Lit 3 next year, but cleaning up the warnings would be nice. Both `lit-element` and `lit-html` have been rolled into `lit` for quite some time.